### PR TITLE
start pointing right, similar to default package

### DIFF
--- a/ipyturtle/example.py
+++ b/ipyturtle/example.py
@@ -43,10 +43,10 @@ class Turtle(widgets.DOMWidget):
     _turtle_width = Int(10).tag(sync=True)
     _turtle_location_x = Float(0.0).tag(sync=True)
     _turtle_location_y = Float(0.0).tag(sync=True)
-    _turtle_heading = Float(90.0).tag(sync=True)
+    _turtle_heading = Float(00.0).tag(sync=True)
 
-    _turtle_heading_x = Float(0).tag(sync=True)
-    _turtle_heading_y = Float(1).tag(sync=True)
+    _turtle_heading_x = Float(1).tag(sync=True)
+    _turtle_heading_y = Float(0).tag(sync=True)
 
     _line = Unicode('').tag(sync=True)
     _current_color = "Black"
@@ -65,8 +65,8 @@ class Turtle(widgets.DOMWidget):
         self._turtle_location_x = 0
         self._turtle_location_y = 0
         self._turtle_heading = 90.0
-        self._turtle_heading_x = 0.0
-        self._turtle_heading_y = 1.0
+        self._turtle_heading_x = 1.0
+        self._turtle_heading_y = 0.0
 
     def position(self):
         return self._turtle_location_x, self._turtle_location_y


### PR DESCRIPTION
https://github.com/gkvoelkl/ipython-turtle-widget/issues/4

some books appear to start pointing up, others pointing right

the default turtle package in python3.6 points right.  This changes the default behavior to right