### PR TITLE
trigger an immediate color change by moving 0

### DIFF
--- a/ipyturtle/example.py
+++ b/ipyturtle/example.py
@@ -128,6 +128,8 @@ class Turtle(widgets.DOMWidget):
 
     def reset(self):
         self._reset()
+        self.pencolor(0, 0, 0)
+        self.forward(0)
         self._line = 'clear'
 
     def pencolor(self,r=-1,g=-1,b=-1):
@@ -142,3 +144,4 @@ class Turtle(widgets.DOMWidget):
         else:
             self._current_color = ""
             self._current_color_rgb = (r,g,b)
+        self.forward(0)


### PR DESCRIPTION
when a student chooses to change the pen color, the turtle does not immediately change color. They must move somewhere for the new color to render.

This adds a move 0, which triggers an immediate color change on the display without further student input


reset changes pen color to black/default

