### PR TITLE
enable simple left() and right() turns

### DIFF
--- a/ipyturtle/example.py
+++ b/ipyturtle/example.py
@@ -95,7 +95,9 @@ class Turtle(widgets.DOMWidget):
     def heading(self):
         return self._turtle_heading
 
-    def left(self, degree):
+    def left(self, degree=None):
+        if degree is None:
+            degree = 90
         self._turtle_heading += degree
         self._turtle_heading = self._turtle_heading % 360
 
@@ -105,7 +107,9 @@ class Turtle(widgets.DOMWidget):
         self._turtle_heading_x = hx
         self._turtle_heading_y = hy
 
-    def right(self, degree):
+    def right(self, degree=None):
+        if degree is None:
+            degree = 90
         self.left(-degree)
 
     def penup(self):

--- a/ipyturtle/example.py
+++ b/ipyturtle/example.py
@@ -95,6 +95,7 @@ class Turtle(widgets.DOMWidget):
     def heading(self):
         return self._turtle_heading
 
+    # def left(self, degree):  # Converting to optional degree
     def left(self, degree=None):
         if degree is None:
             degree = 90
@@ -107,6 +108,7 @@ class Turtle(widgets.DOMWidget):
         self._turtle_heading_x = hx
         self._turtle_heading_y = hy
 
+    # def right(self, degree):  # Converting to optional degree
     def right(self, degree=None):
         if degree is None:
             degree = 90


### PR DESCRIPTION
Bringing the idea of specific degrees brings complexity to a topic that need not be complicated.

This introduces commands to allow simple left() and right() commands that will turn 90 degrees in either direction without needing to discuss degrees.

Students have an innate understanding of the meaning of left and right.  

Change allows the students to introduce movement using left and right and slowly introduce the concept of degrees.